### PR TITLE
Standardize API error responses

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -21,4 +21,10 @@ export const cast = pgTable("cast", {
 
   // duration per claim/tick in milliseconds
   claimInterval: integer("claim_interval").notNull(),
+
+  // when set, the cast has been suspended/ended
+  endedAt: timestamp("ended_at", {
+    mode: "string",
+    withTimezone: true,
+  }),
 });

--- a/src/routes/cast.test.ts
+++ b/src/routes/cast.test.ts
@@ -1,5 +1,7 @@
 import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
+import { isNull } from "drizzle-orm";
+import { cast } from "../db/schema.js";
 
 let app: Hono;
 let db: any;
@@ -14,7 +16,8 @@ beforeAll(async () => {
     started_at timestamptz NOT NULL,
     claimed integer NOT NULL DEFAULT 0,
     claim_max integer,
-    claim_interval integer NOT NULL
+    claim_interval integer NOT NULL,
+    ended_at timestamptz
   );`);
   const castModule = await import("./cast.js");
   app = new Hono().route("/cast", castModule.default);
@@ -30,7 +33,14 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("cast router", () => {
+  describe("cast router", () => {
+    it("returns structured error when no cast active", async () => {
+      const res = await app.request("/cast");
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error.message).toBe("no active cast");
+    });
+
   it("starts a new cast and returns eta", async () => {
     const res = await app.request("/cast", {
       method: "POST",
@@ -40,6 +50,23 @@ describe("cast router", () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.data.eta).toBe(2000);
+  });
+
+  it("suspends existing cast instead of deleting", async () => {
+    const payload = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ skillId: "fishing", targetId: "little_pond" }),
+    };
+
+    await app.request("/cast", payload);
+    await app.request("/cast", payload);
+
+    const all = await db.select().from(cast);
+    expect(all.length).toBe(2);
+
+    const active = await db.select().from(cast).where(isNull(cast.endedAt));
+    expect(active.length).toBe(1);
   });
 
   it("allows claiming after interval", async () => {


### PR DESCRIPTION
## Summary
- add helper to format API errors consistently
- unify error handling across cast routes and return JSON for delete
- test structured error response
- suspend casts instead of deleting to retain history

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c3e0cc7698832bbd52b4d8b486beef