### PR TITLE
feat: add duplicant and schedule routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 
 # deps
 node_modules/
+dist/
+:memory:
 
 # env
 .env

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,5 +1,35 @@
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
+import { eq } from "drizzle-orm";
+import { schedule } from "./schema.js";
+import type { ScheduleActivity } from "./schema.js";
+
+export const DEFAULT_SCHEDULE_ID = "default";
+export const DEFAULT_SCHEDULE_ACTIVITIES: ScheduleActivity[] = [
+  // midnight–8AM bedtime
+  ...Array(8).fill("bedtime"),
+  // 8–9AM bathtime
+  "bathtime",
+  // 9AM–5PM work hours
+  ...Array(8).fill("work"),
+  // 5–midnight downtime
+  ...Array(7).fill("downtime"),
+];
 
 const client = new PGlite(process.env.PG_DATA ?? "./pg_data");
-export default drizzle({ client });
+const db = drizzle({ client });
+
+export async function ensureDefaultSchedule() {
+  const existing = await db
+    .select({ id: schedule.id })
+    .from(schedule)
+    .where(eq(schedule.id, DEFAULT_SCHEDULE_ID));
+  if (existing.length === 0) {
+    await db.insert(schedule).values({
+      id: DEFAULT_SCHEDULE_ID,
+      activities: DEFAULT_SCHEDULE_ACTIVITIES,
+    });
+  }
+}
+
+export default db;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,2 +1,46 @@
-import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { pgEnum, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
 import { nanoid } from "nanoid";
+
+export const scheduleActivityEnum = pgEnum("schedule_activity", [
+  "work",
+  "bedtime",
+  "downtime",
+  "bathtime",
+]);
+
+export const schedule = pgTable("schedule", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => nanoid()),
+  activities: scheduleActivityEnum("activities").array(24).notNull(),
+});
+
+export const duplicant = pgTable("duplicant", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => nanoid()),
+  name: text("name").notNull(),
+  scheduleId: text("schedule_id").references(() => schedule.id),
+  createdAt: timestamp("created_at", { withTimezone: false })
+    .defaultNow()
+    .notNull(),
+});
+
+export const scheduleRelations = relations(schedule, ({ many }) => ({
+  duplicants: many(duplicant),
+}));
+
+export const duplicantRelations = relations(duplicant, ({ one }) => ({
+  schedule: one(schedule, {
+    fields: [duplicant.scheduleId],
+    references: [schedule.id],
+  }),
+}));
+
+export type Duplicant = typeof duplicant.$inferSelect;
+export type NewDuplicant = typeof duplicant.$inferInsert;
+
+export type Schedule = typeof schedule.$inferSelect;
+export type NewSchedule = typeof schedule.$inferInsert;
+export type ScheduleActivity = (typeof scheduleActivityEnum.enumValues)[number];

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,13 @@ import "dotenv/config";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 
+import duplicantRoute from "./routes/duplicant.js";
+import scheduleRoute from "./routes/schedule.js";
+import { ensureDefaultSchedule } from "./db/index.js";
+
 const api = new Hono();
+api.route("/duplicants", duplicantRoute);
+api.route("/schedules", scheduleRoute);
 
 const app = new Hono();
 app.get("/", (c) => {
@@ -13,6 +19,8 @@ app.get("/", (c) => {
 app.route("/api/v1", api);
 
 const defaultPort = parseInt(process.env.PORT ?? "3000");
+
+await ensureDefaultSchedule();
 
 serve(
   {

--- a/src/routes/duplicant.ts
+++ b/src/routes/duplicant.ts
@@ -1,0 +1,25 @@
+import { Hono } from "hono";
+import db, { DEFAULT_SCHEDULE_ID } from "../db/index.js";
+import { duplicant } from "../db/schema.js";
+import type { NewDuplicant } from "../db/schema.js";
+
+const duplicantRoute = new Hono();
+
+duplicantRoute.get("/", async (c) => {
+  const result = await db.select().from(duplicant);
+  return c.json(result);
+});
+
+duplicantRoute.post("/", async (c) => {
+  const body = await c.req.json<NewDuplicant>();
+  const [created] = await db
+    .insert(duplicant)
+    .values({
+      name: body.name,
+      scheduleId: body.scheduleId ?? DEFAULT_SCHEDULE_ID,
+    })
+    .returning();
+  return c.json(created, 201);
+});
+
+export default duplicantRoute;

--- a/src/routes/schedule.ts
+++ b/src/routes/schedule.ts
@@ -1,0 +1,25 @@
+import { Hono } from "hono";
+import db from "../db/index.js";
+import { schedule } from "../db/schema.js";
+import type { NewSchedule } from "../db/schema.js";
+
+const scheduleRoute = new Hono();
+
+scheduleRoute.get("/", async (c) => {
+  const result = await db.select().from(schedule);
+  return c.json(result);
+});
+
+scheduleRoute.post("/", async (c) => {
+  const body = await c.req.json<NewSchedule>();
+  if (!Array.isArray(body.activities) || body.activities.length !== 24) {
+    return c.text("activities must contain 24 items", 400);
+  }
+  const [created] = await db
+    .insert(schedule)
+    .values({ activities: body.activities })
+    .returning();
+  return c.json(created, 201);
+});
+
+export default scheduleRoute;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,0 +1,111 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { sql } from "drizzle-orm";
+
+process.env.PG_DATA = ":memory:";
+
+// Dynamic imports to ensure PG_DATA is set before modules load
+let scheduleRoute: Hono;
+let duplicantRoute: Hono;
+let db: any;
+let ensureDefaultSchedule: any;
+let DEFAULT_SCHEDULE_ID: string;
+let DEFAULT_SCHEDULE_ACTIVITIES: string[];
+let app: Hono;
+
+beforeAll(async () => {
+  const dbModule = await import("../src/db/index.js");
+  db = dbModule.default;
+  ensureDefaultSchedule = dbModule.ensureDefaultSchedule;
+  DEFAULT_SCHEDULE_ID = dbModule.DEFAULT_SCHEDULE_ID;
+  DEFAULT_SCHEDULE_ACTIVITIES = dbModule.DEFAULT_SCHEDULE_ACTIVITIES;
+  scheduleRoute = (await import("../src/routes/schedule.js")).default;
+  duplicantRoute = (await import("../src/routes/duplicant.js")).default;
+  app = new Hono();
+  app.route("/schedules", scheduleRoute);
+  app.route("/duplicants", duplicantRoute);
+
+  await db.execute(sql`DROP TYPE IF EXISTS schedule_activity CASCADE`);
+  await db.execute(sql`
+    CREATE TYPE schedule_activity AS ENUM ('work','bedtime','downtime','bathtime')
+  `);
+  await db.execute(sql`DROP TABLE IF EXISTS schedule CASCADE`);
+  await db.execute(sql`
+    CREATE TABLE schedule (
+      id text PRIMARY KEY,
+      activities schedule_activity[24] NOT NULL
+    )
+  `);
+  await db.execute(sql`DROP TABLE IF EXISTS duplicant CASCADE`);
+  await db.execute(sql`
+    CREATE TABLE duplicant (
+      id text PRIMARY KEY,
+      name text NOT NULL,
+      schedule_id text REFERENCES schedule(id),
+      created_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+    )
+  `);
+  await ensureDefaultSchedule();
+});
+
+describe("API routes", () => {
+  it("seeds a 9-to-5 work default schedule", () => {
+    expect(DEFAULT_SCHEDULE_ACTIVITIES.slice(0, 8)).toEqual(
+      Array(8).fill("bedtime"),
+    );
+    expect(DEFAULT_SCHEDULE_ACTIVITIES[8]).toBe("bathtime");
+    expect(DEFAULT_SCHEDULE_ACTIVITIES.slice(9, 17)).toEqual(
+      Array(8).fill("work"),
+    );
+    expect(DEFAULT_SCHEDULE_ACTIVITIES.slice(17)).toEqual(
+      Array(7).fill("downtime"),
+    );
+  });
+
+  it("creates and lists schedules", async () => {
+    const activities = Array(24).fill("work");
+    const create = await app.request("/schedules", {
+      method: "POST",
+      body: JSON.stringify({ activities }),
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(create.status).toBe(201);
+    const created = await create.json();
+    expect(created.activities).toHaveLength(24);
+
+    const list = await app.request("/schedules");
+    const schedules = await list.json();
+    const defaultSchedule = schedules.find(
+      (s: any) => s.id === DEFAULT_SCHEDULE_ID,
+    );
+    expect(defaultSchedule).toBeDefined();
+    expect(defaultSchedule.activities).toEqual(DEFAULT_SCHEDULE_ACTIVITIES);
+    expect(schedules.length).toBe(2);
+  });
+
+  it("rejects schedules with fewer than 24 activities", async () => {
+    const activities = Array(23).fill("work");
+    const res = await app.request("/schedules", {
+      method: "POST",
+      body: JSON.stringify({ activities }),
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("creates duplicant without schedule", async () => {
+    const create = await app.request("/duplicants", {
+      method: "POST",
+      body: JSON.stringify({ name: "Bubbles" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(create.status).toBe(201);
+    const created = await create.json();
+    expect(created.name).toBe("Bubbles");
+    expect(created.scheduleId).toBe(DEFAULT_SCHEDULE_ID);
+
+    const list = await app.request("/duplicants");
+    const duplicants = await list.json();
+    expect(duplicants.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- rename tables to singular `duplicant` and `schedule`
- expose HTTP routes for duplicants and schedules
- seed a default schedule at startup and use it for duplicants without an explicit schedule
- restrict schedule activities to four types and enforce 24-hour length
- set the default schedule to a real-world day: bedtime overnight, bathtime at 8am, work from 9am–5pm, then downtime
- add tests covering schedule validation, duplicant creation, and the default 9–5 layout

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c7829cdd24832b8b0c750919217a4e