### PR TITLE
feat: add task management for duplicants

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,13 @@ import { Hono } from "hono";
 
 import duplicantRoute from "./routes/duplicant.js";
 import scheduleRoute from "./routes/schedule.js";
+import taskRoute from "./routes/task.js";
 import { ensureDefaultSchedule } from "./db/index.js";
 
 const api = new Hono();
 api.route("/duplicants", duplicantRoute);
 api.route("/schedules", scheduleRoute);
+api.route("/", taskRoute);
 
 const app = new Hono();
 app.get("/", (c) => {

--- a/src/routes/task.test.ts
+++ b/src/routes/task.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Hono } from 'hono';
+import { asc, desc } from 'drizzle-orm';
+import { task } from '../db/schema.js';
+
+var selectMock: any;
+var insertMock: any;
+
+vi.mock('../db/index.js', () => {
+  selectMock = vi.fn();
+  insertMock = vi.fn();
+  return {
+    default: {
+      select: (...args: any[]) => selectMock(...args),
+      insert: (...args: any[]) => insertMock(...args),
+    },
+  };
+});
+
+import taskRoute from './task';
+
+describe('taskRoute', () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+    insertMock.mockReset();
+  });
+
+  it('GET /duplicants/:id/tasks returns tasks', async () => {
+    const tasks = [
+      {
+        id: 't1',
+        duplicantId: 'd1',
+        description: 'Dig',
+        status: 'pending',
+        duration: 2,
+        priority: 6,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+    const orderByMock = vi.fn().mockResolvedValue(tasks);
+    selectMock.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: orderByMock,
+        }),
+      }),
+    });
+
+    const app = new Hono();
+    app.route('/', taskRoute);
+
+    const res = await app.request('/duplicants/d1/tasks');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(tasks);
+    expect(orderByMock).toHaveBeenCalledWith(desc(task.priority), asc(task.createdAt));
+  });
+
+  it('POST /duplicants/:id/tasks creates a task', async () => {
+    insertMock.mockReturnValue({
+      values: (v: any) => ({
+        returning: () => Promise.resolve([{ id: 't1', ...v }]),
+      }),
+    });
+
+    const app = new Hono();
+    app.route('/', taskRoute);
+
+    const res = await app.request('/duplicants/d1/tasks', {
+      method: 'POST',
+      body: JSON.stringify({ description: 'Build ladder', duration: 3, priority: 7 }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({
+      id: 't1',
+      duplicantId: 'd1',
+      description: 'Build ladder',
+      duration: 3,
+      priority: 7,
+      status: 'pending',
+    });
+  });
+});
+

--- a/src/routes/task.ts
+++ b/src/routes/task.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+import db from "../db/index.js";
+import { task } from "../db/schema.js";
+import type { NewTask } from "../db/schema.js";
+import { eq, asc, desc } from "drizzle-orm";
+
+const taskRoute = new Hono();
+
+// GET /duplicants/:id/tasks
+taskRoute.get("/duplicants/:id/tasks", async (c) => {
+  const duplicantId = c.req.param("id");
+  const result = await db
+    .select()
+    .from(task)
+    .where(eq(task.duplicantId, duplicantId))
+    .orderBy(desc(task.priority), asc(task.createdAt));
+  return c.json(result);
+});
+
+// POST /duplicants/:id/tasks
+taskRoute.post("/duplicants/:id/tasks", async (c) => {
+  const duplicantId = c.req.param("id");
+  const body = await c.req.json<
+    Pick<NewTask, "description" | "status" | "duration" | "priority">
+  >();
+  const [created] = await db
+    .insert(task)
+    .values({
+      duplicantId,
+      description: body.description,
+      duration: body.duration,
+      priority: body.priority ?? 5,
+      status: body.status ?? "pending",
+    })
+    .returning();
+  return c.json(created, 201);
+});
+
+// PATCH /tasks/:taskId
+taskRoute.patch("/tasks/:taskId", async (c) => {
+  const taskId = c.req.param("taskId");
+  const body = await c.req.json<
+    Partial<Pick<NewTask, "description" | "status" | "duration" | "priority">>
+  >();
+  const updateData: Record<string, any> = {};
+  if (body.description !== undefined) updateData.description = body.description;
+  if (body.status !== undefined) updateData.status = body.status;
+  if (body.duration !== undefined) updateData.duration = body.duration;
+  if (body.priority !== undefined) updateData.priority = body.priority;
+  const [updated] = await db
+    .update(task)
+    .set(updateData)
+    .where(eq(task.id, taskId))
+    .returning();
+  return c.json(updated);
+});
+
+export default taskRoute;


### PR DESCRIPTION
## Summary
- define `task` table with relations to `duplicant`
- expose API endpoints for listing, creating and updating tasks
- register task routes and add unit tests
- add duration to tasks and ensure tasks are returned in queue order
- add basic priority and order tasks by priority

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c79ebdd100832bb3ae0ab5f60e9fa4