### PR TITLE
test: expand route coverage

### DIFF
--- a/src/routes/duplicant.test.ts
+++ b/src/routes/duplicant.test.ts
@@ -65,5 +65,29 @@ describe('duplicantRoute', () => {
     expect(await res.json()).toEqual({ id: 'd1', name: 'Ada', scheduleId: 'default' });
     expect(valuesSpy).toHaveBeenCalledWith({ name: 'Ada', scheduleId: 'default' });
   });
+
+  it('POST / uses provided schedule id when supplied', async () => {
+    insertMock.mockReturnValue({
+      values: (v: any) => {
+        valuesSpy(v);
+        return {
+          returning: () => Promise.resolve([{ id: 'd2', ...v }]),
+        };
+      },
+    });
+
+    const app = new Hono();
+    app.route('/', duplicantRoute);
+
+    const res = await app.request('/', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Bert', scheduleId: 'custom' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ id: 'd2', name: 'Bert', scheduleId: 'custom' });
+    expect(valuesSpy).toHaveBeenCalledWith({ name: 'Bert', scheduleId: 'custom' });
+  });
 });
 

--- a/src/routes/schedule.test.ts
+++ b/src/routes/schedule.test.ts
@@ -72,5 +72,18 @@ describe('scheduleRoute', () => {
 
     expect(res.status).toBe(400);
   });
+
+  it('POST / validates activities is an array', async () => {
+    const app = new Hono();
+    app.route('/', scheduleRoute);
+
+    const res = await app.request('/', {
+      method: 'POST',
+      body: JSON.stringify({ activities: 'not-an-array' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(res.status).toBe(400);
+  });
 });
 


### PR DESCRIPTION
## Summary
- expand task route tests to cover default values and full updates
- verify duplicant creation with explicit schedule ids
- ensure schedule route rejects non-array activity lists

## Testing
- `pnpm test`
- `node_modules/.bin/vitest run --coverage` *(fails: Cannot find dependency '@vitest/coverage-v8')*

------
https://chatgpt.com/codex/tasks/task_e_68c7b586ca28832ba26ddb8fe37eb5aa