### PR TITLE
Add server startup test for full coverage

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const serveMock = vi.fn();
+const ensureDefaultScheduleMock = vi.fn();
+
+vi.mock('@hono/node-server', () => ({
+  serve: serveMock,
+}));
+
+vi.mock('./db/index.js', () => ({
+  ensureDefaultSchedule: ensureDefaultScheduleMock,
+}));
+
+describe('index', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    serveMock.mockReset();
+    ensureDefaultScheduleMock.mockReset();
+    delete process.env.PORT;
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('boots server on default port', async () => {
+    await import('./index');
+    expect(ensureDefaultScheduleMock).toHaveBeenCalled();
+    const [opts, cb] = serveMock.mock.calls[0];
+    expect(opts.port).toBe(3000);
+    cb({ port: opts.port });
+    expect(console.log).toHaveBeenCalledWith(
+      `Server is running on http://localhost:${opts.port}`,
+    );
+  });
+
+  it('respects PORT environment variable', async () => {
+    process.env.PORT = '4321';
+    await import('./index');
+    const [opts, cb] = serveMock.mock.calls[0];
+    expect(opts.port).toBe(4321);
+    cb({ port: opts.port });
+    expect(console.log).toHaveBeenCalledWith(
+      `Server is running on http://localhost:${opts.port}`,
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- cover `index.ts` server initialization and port selection

## Testing
- `pnpm test --coverage` *(fails: Cannot find dependency '@vitest/coverage-v8')*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7b6c01e80832b81982203cedd75b2