### PR TITLE
feat: manage duplicant tasks sequentially

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -9,6 +9,18 @@ export const scheduleActivityEnum = pgEnum("schedule_activity", [
   "bathtime",
 ]);
 
+export const taskStatusEnum = pgEnum("task_status", [
+  "pending",
+  "in-progress",
+  "complete",
+]);
+
+export const TASK_STATUS = {
+  PENDING: "pending",
+  IN_PROGRESS: "in-progress",
+  COMPLETE: "complete",
+} as const;
+
 export const schedule = pgTable("schedule", {
   id: text("id")
     .primaryKey()
@@ -37,7 +49,7 @@ export const task = pgTable("task", {
   description: text("description").notNull(),
   priority: integer("priority").notNull().default(5),
   duration: integer("duration").notNull(),
-  status: text("status").notNull().default("pending"),
+  status: taskStatusEnum("status").notNull().default(TASK_STATUS.PENDING),
   createdAt: timestamp("created_at", { withTimezone: false })
     .defaultNow()
     .notNull(),
@@ -71,3 +83,4 @@ export type NewTask = typeof task.$inferInsert;
 export type Schedule = typeof schedule.$inferSelect;
 export type NewSchedule = typeof schedule.$inferInsert;
 export type ScheduleActivity = (typeof scheduleActivityEnum.enumValues)[number];
+export type TaskStatus = (typeof taskStatusEnum.enumValues)[number];

--- a/src/routes/task.ts
+++ b/src/routes/task.ts
@@ -1,10 +1,41 @@
 import { Hono } from "hono";
 import db from "../db/index.js";
-import { task } from "../db/schema.js";
+import { task, TASK_STATUS } from "../db/schema.js";
 import type { NewTask } from "../db/schema.js";
-import { eq, asc, desc } from "drizzle-orm";
+import { eq, asc, desc, and, ne } from "drizzle-orm";
 
 const taskRoute = new Hono();
+
+// Schedule the next task so only one is in progress for a duplicant.
+export async function scheduleNextTask(duplicantId: string) {
+  // Reset any running task to pending first
+  await db
+    .update(task)
+    .set({ status: TASK_STATUS.PENDING })
+    .where(
+      and(
+        eq(task.duplicantId, duplicantId),
+        eq(task.status, TASK_STATUS.IN_PROGRESS),
+      ),
+    );
+
+  // Find next task based on priority then creation time
+  const [next] = await db
+    .select()
+    .from(task)
+    .where(
+      and(eq(task.duplicantId, duplicantId), ne(task.status, TASK_STATUS.COMPLETE)),
+    )
+    .orderBy(desc(task.priority), asc(task.createdAt))
+    .limit(1);
+
+  if (next) {
+    await db
+      .update(task)
+      .set({ status: TASK_STATUS.IN_PROGRESS })
+      .where(eq(task.id, next.id));
+  }
+}
 
 // GET /duplicants/:id/tasks
 taskRoute.get("/duplicants/:id/tasks", async (c) => {
@@ -15,6 +46,23 @@ taskRoute.get("/duplicants/:id/tasks", async (c) => {
     .where(eq(task.duplicantId, duplicantId))
     .orderBy(desc(task.priority), asc(task.createdAt));
   return c.json(result);
+});
+
+// GET /duplicants/:id/tasks/current
+taskRoute.get("/duplicants/:id/tasks/current", async (c) => {
+  const duplicantId = c.req.param("id");
+  const [current] = await db
+    .select()
+    .from(task)
+    .where(
+      and(
+        eq(task.duplicantId, duplicantId),
+        eq(task.status, TASK_STATUS.IN_PROGRESS),
+      ),
+    )
+    .limit(1);
+  if (!current) return c.notFound();
+  return c.json(current);
 });
 
 // POST /duplicants/:id/tasks
@@ -31,30 +79,36 @@ taskRoute.post("/duplicants/:id/tasks", async (c) => {
       description: body.description,
       duration: body.duration,
       priority: body.priority ?? 5,
-      status: body.status ?? "pending",
+      status: body.status ?? TASK_STATUS.PENDING,
     })
     .returning();
+  await scheduleNextTask(duplicantId);
   return c.json(created, 201);
 });
 
-// PATCH /tasks/:taskId
-taskRoute.patch("/tasks/:taskId", async (c) => {
+// DELETE /tasks/:taskId
+taskRoute.delete("/tasks/:taskId", async (c) => {
   const taskId = c.req.param("taskId");
-  const body =
-    await c.req.json<
-      Partial<Pick<NewTask, "description" | "status" | "duration" | "priority">>
-    >();
-  const updateData: Record<string, any> = {};
-  if (body.description !== undefined) updateData.description = body.description;
-  if (body.status !== undefined) updateData.status = body.status;
-  if (body.duration !== undefined) updateData.duration = body.duration;
-  if (body.priority !== undefined) updateData.priority = body.priority;
-  const [updated] = await db
-    .update(task)
-    .set(updateData)
+  const [deleted] = await db
+    .delete(task)
     .where(eq(task.id, taskId))
     .returning();
-  return c.json(updated);
+  if (!deleted) return c.notFound();
+  await scheduleNextTask(deleted.duplicantId);
+  return c.json(deleted);
+});
+
+// POST /tasks/:taskId/claim
+taskRoute.post("/tasks/:taskId/claim", async (c) => {
+  const taskId = c.req.param("taskId");
+  const [claimed] = await db
+    .update(task)
+    .set({ status: TASK_STATUS.COMPLETE })
+    .where(eq(task.id, taskId))
+    .returning();
+  if (!claimed) return c.notFound();
+  await scheduleNextTask(claimed.duplicantId);
+  return c.json(claimed);
 });
 
 export default taskRoute;


### PR DESCRIPTION
## Summary
- rename scheduler helper to `scheduleNextTask` and update task routes to use it
- remove `PATCH /tasks/:taskId` endpoint and related tests
- schedule next task after creating, deleting, or claiming tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d056c8bc832bb995ae807e422773