### PR TITLE
Split API route groups and tests into dedicated modules

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,13 +2,21 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const serveMock = vi.fn();
 const ensureDefaultScheduleMock = vi.fn();
+const dbMock = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
 
 vi.mock("@hono/node-server", () => ({
   serve: serveMock,
 }));
 
 vi.mock("./db/index.js", () => ({
+  __esModule: true,
   ensureDefaultSchedule: ensureDefaultScheduleMock,
+  default: dbMock,
 }));
 
 describe("index", () => {
@@ -17,6 +25,7 @@ describe("index", () => {
     vi.resetModules();
     serveMock.mockReset();
     ensureDefaultScheduleMock.mockReset();
+    Object.values(dbMock).forEach((fn) => fn.mockReset?.());
     delete process.env.PORT;
     vi.spyOn(console, "log").mockImplementation(() => {});
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,17 @@ import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 
 import { ensureDefaultSchedule } from "./db/index.js";
+import { api } from "./routes/api.js";
 
-const api = new Hono();
 const app = new Hono();
+
 app.get("/", (c) => {
   return c.text("Hello Hono!");
 });
 
 app.route("/api/v1", api);
+
+export { app, api };
 
 const defaultPort = parseInt(process.env.PORT ?? "3000");
 

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,0 +1,13 @@
+import { Hono } from "hono";
+
+import { duplicantRoutes } from "./duplicant.js";
+import { scheduleRoutes } from "./schedule.js";
+import { taskRoutes } from "./task.js";
+
+const api = new Hono();
+
+api.route("/schedule", scheduleRoutes);
+api.route("/task", taskRoutes);
+api.route("/duplicant", duplicantRoutes);
+
+export { api };

--- a/src/routes/duplicant.test.ts
+++ b/src/routes/duplicant.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createDuplicantRoutes } from "./duplicant.js";
+
+vi.mock("../db/index.js", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+type Database = Parameters<typeof createDuplicantRoutes>[0];
+
+type DbMock = {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+describe("duplicant routes", () => {
+  let dbMock: DbMock;
+
+  beforeEach(() => {
+    dbMock = {
+      select: vi.fn(),
+      insert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+  });
+
+  it("creates a duplicant with nullable relationships", async () => {
+    const returning = vi
+      .fn()
+      .mockResolvedValue([
+        { id: "1", name: "Ada", task: null, schedule: null },
+      ]);
+    const values = vi.fn().mockReturnValue({ returning });
+    dbMock.insert.mockReturnValue({ values });
+
+    const routes = createDuplicantRoutes(dbMock as unknown as Database);
+    const response = await routes.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Ada" }),
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      id: "1",
+      name: "Ada",
+      task: null,
+      schedule: null,
+    });
+    expect(values).toHaveBeenCalledWith({
+      name: "Ada",
+      task: null,
+      schedule: null,
+    });
+  });
+
+  it("returns 404 when deleting a missing duplicant", async () => {
+    const returning = vi.fn().mockResolvedValue([]);
+    const where = vi.fn().mockReturnValue({ returning });
+    dbMock.delete.mockReturnValue({ where });
+
+    const routes = createDuplicantRoutes(dbMock as unknown as Database);
+    const response = await routes.request("/missing", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Duplicant not found",
+    });
+    expect(where).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/routes/duplicant.ts
+++ b/src/routes/duplicant.ts
@@ -1,0 +1,114 @@
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+import db from "../db/index.js";
+import { duplicant } from "../db/schema.js";
+import type { NewDuplicant } from "../db/schema.js";
+import { parseRequestBody, removeUndefined } from "./utils.js";
+
+type Database = typeof db;
+
+const duplicantBaseSchema = z.object({
+  name: z.string().min(1),
+  task: z.string().min(1).nullable().optional(),
+  schedule: z.string().min(1).nullable().optional(),
+});
+
+const duplicantCreateSchema = duplicantBaseSchema.extend({
+  id: z.string().min(1).optional(),
+});
+
+const duplicantUpdateSchema = duplicantBaseSchema
+  .partial()
+  .refine(
+    (data) => Object.values(data).some((value) => value !== undefined),
+    { message: "At least one field must be provided" },
+  );
+
+export function createDuplicantRoutes(database: Database = db) {
+  const routes = new Hono();
+
+  routes.get("/", async (c) => {
+    const items = await database.select().from(duplicant);
+    return c.json(items);
+  });
+
+  routes.get("/:id", async (c) => {
+    const { id } = c.req.param();
+    const result = await database
+      .select()
+      .from(duplicant)
+      .where(eq(duplicant.id, id));
+    if (result.length === 0) {
+      return c.json({ error: "Duplicant not found" }, 404);
+    }
+    return c.json(result[0]);
+  });
+
+  routes.post("/", async (c) => {
+    const parsed = await parseRequestBody(
+      c,
+      duplicantCreateSchema,
+      "Invalid duplicant payload",
+    );
+    if (!parsed.success) {
+      return parsed.response;
+    }
+
+    const { id, ...rest } = parsed.data;
+    const values: NewDuplicant = {
+      name: rest.name,
+      task: rest.task ?? null,
+      schedule: rest.schedule ?? null,
+    };
+    if (id) {
+      values.id = id;
+    }
+
+    const inserted = await database
+      .insert(duplicant)
+      .values(values)
+      .returning();
+    return c.json(inserted[0], 201);
+  });
+
+  routes.post("/:id", async (c) => {
+    const { id } = c.req.param();
+    const parsed = await parseRequestBody(
+      c,
+      duplicantUpdateSchema,
+      "Invalid duplicant payload",
+    );
+    if (!parsed.success) {
+      return parsed.response;
+    }
+
+    const updateData: Partial<NewDuplicant> = removeUndefined(parsed.data);
+    const updated = await database
+      .update(duplicant)
+      .set(updateData)
+      .where(eq(duplicant.id, id))
+      .returning();
+    if (updated.length === 0) {
+      return c.json({ error: "Duplicant not found" }, 404);
+    }
+    return c.json(updated[0]);
+  });
+
+  routes.delete("/:id", async (c) => {
+    const { id } = c.req.param();
+    const deleted = await database
+      .delete(duplicant)
+      .where(eq(duplicant.id, id))
+      .returning();
+    if (deleted.length === 0) {
+      return c.json({ error: "Duplicant not found" }, 404);
+    }
+    return c.json(deleted[0]);
+  });
+
+  return routes;
+}
+
+export const duplicantRoutes = createDuplicantRoutes();

--- a/src/routes/schedule.test.ts
+++ b/src/routes/schedule.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createScheduleRoutes } from "./schedule.js";
+
+vi.mock("../db/index.js", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+type Database = Parameters<typeof createScheduleRoutes>[0];
+
+type DbMock = {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+const scheduleActivities = Array.from({ length: 24 }, () => "work");
+
+describe("schedule routes", () => {
+  let dbMock: DbMock;
+
+  beforeEach(() => {
+    dbMock = {
+      select: vi.fn(),
+      insert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+  });
+
+  it("lists schedules from the database", async () => {
+    const schedules = [{ id: "1", activities: scheduleActivities }];
+    const from = vi.fn().mockResolvedValue(schedules);
+    dbMock.select.mockReturnValue({ from });
+
+    const routes = createScheduleRoutes(dbMock as unknown as Database);
+    const response = await routes.request("/", { method: "GET" });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(schedules);
+    expect(dbMock.select).toHaveBeenCalledTimes(1);
+    expect(from).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 404 when updating a missing schedule", async () => {
+    const returning = vi.fn().mockResolvedValue([]);
+    const where = vi.fn().mockReturnValue({ returning });
+    const set = vi.fn().mockReturnValue({ where });
+    dbMock.update.mockReturnValue({ set });
+
+    const routes = createScheduleRoutes(dbMock as unknown as Database);
+    const response = await routes.request("/missing", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ activities: scheduleActivities }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Schedule not found",
+    });
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(where).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/routes/schedule.ts
+++ b/src/routes/schedule.ts
@@ -1,0 +1,117 @@
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+import db from "../db/index.js";
+import {
+  schedule,
+  scheduleActivityEnum,
+} from "../db/schema.js";
+import type {
+  NewSchedule,
+  ScheduleActivity,
+} from "../db/schema.js";
+import { parseRequestBody } from "./utils.js";
+
+type Database = typeof db;
+
+const scheduleActivitySchema = z.enum(
+  scheduleActivityEnum.enumValues as [
+    ScheduleActivity,
+    ...ScheduleActivity[],
+  ],
+);
+
+const scheduleActivitiesSchema = z
+  .array(scheduleActivitySchema)
+  .length(24, { message: "activities must contain 24 entries" });
+
+const scheduleCreateSchema = z.object({
+  id: z.string().min(1).optional(),
+  activities: scheduleActivitiesSchema,
+});
+
+const scheduleUpdateSchema = z.object({
+  activities: scheduleActivitiesSchema,
+});
+
+export function createScheduleRoutes(database: Database = db) {
+  const routes = new Hono();
+
+  routes.get("/", async (c) => {
+    const items = await database.select().from(schedule);
+    return c.json(items);
+  });
+
+  routes.get("/:id", async (c) => {
+    const { id } = c.req.param();
+    const result = await database
+      .select()
+      .from(schedule)
+      .where(eq(schedule.id, id));
+    if (result.length === 0) {
+      return c.json({ error: "Schedule not found" }, 404);
+    }
+    return c.json(result[0]);
+  });
+
+  routes.post("/", async (c) => {
+    const parsed = await parseRequestBody(
+      c,
+      scheduleCreateSchema,
+      "Invalid schedule payload",
+    );
+    if (!parsed.success) {
+      return parsed.response;
+    }
+
+    const { id, activities } = parsed.data;
+    const values: NewSchedule = {
+      activities,
+    };
+    if (id) {
+      values.id = id;
+    }
+
+    const inserted = await database.insert(schedule).values(values).returning();
+    return c.json(inserted[0], 201);
+  });
+
+  routes.post("/:id", async (c) => {
+    const { id } = c.req.param();
+    const parsed = await parseRequestBody(
+      c,
+      scheduleUpdateSchema,
+      "Invalid schedule payload",
+    );
+    if (!parsed.success) {
+      return parsed.response;
+    }
+
+    const updated = await database
+      .update(schedule)
+      .set(parsed.data)
+      .where(eq(schedule.id, id))
+      .returning();
+    if (updated.length === 0) {
+      return c.json({ error: "Schedule not found" }, 404);
+    }
+    return c.json(updated[0]);
+  });
+
+  routes.delete("/:id", async (c) => {
+    const { id } = c.req.param();
+    const deleted = await database
+      .delete(schedule)
+      .where(eq(schedule.id, id))
+      .returning();
+    if (deleted.length === 0) {
+      return c.json({ error: "Schedule not found" }, 404);
+    }
+    return c.json(deleted[0]);
+  });
+
+  return routes;
+}
+
+export const scheduleRoutes = createScheduleRoutes();

--- a/src/routes/task.test.ts
+++ b/src/routes/task.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTaskRoutes } from "./task.js";
+
+vi.mock("../db/index.js", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+type Database = Parameters<typeof createTaskRoutes>[0];
+
+type DbMock = {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+describe("task routes", () => {
+  let dbMock: DbMock;
+
+  beforeEach(() => {
+    dbMock = {
+      select: vi.fn(),
+      insert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+  });
+
+  it("creates a new task with nullable target", async () => {
+    const returning = vi
+      .fn()
+      .mockResolvedValue([
+        { id: "1", description: "desc", skill: "skill", target: null },
+      ]);
+    const values = vi.fn().mockReturnValue({ returning });
+    dbMock.insert.mockReturnValue({ values });
+
+    const routes = createTaskRoutes(dbMock as unknown as Database);
+    const response = await routes.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ description: "desc", skill: "skill" }),
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      id: "1",
+      description: "desc",
+      skill: "skill",
+      target: null,
+    });
+    expect(values).toHaveBeenCalledWith({
+      description: "desc",
+      skill: "skill",
+      target: null,
+    });
+  });
+
+  it("updates an existing task with provided fields", async () => {
+    const returning = vi
+      .fn()
+      .mockResolvedValue([
+        {
+          id: "1",
+          description: "updated",
+          skill: "skill",
+          target: "target",
+        },
+      ]);
+    const where = vi.fn().mockReturnValue({ returning });
+    const set = vi.fn().mockReturnValue({ where });
+    dbMock.update.mockReturnValue({ set });
+
+    const routes = createTaskRoutes(dbMock as unknown as Database);
+    const response = await routes.request("/1", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ description: "updated" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "1",
+      description: "updated",
+      skill: "skill",
+      target: "target",
+    });
+    expect(set).toHaveBeenCalledWith({ description: "updated" });
+    expect(where).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/routes/task.ts
+++ b/src/routes/task.ts
@@ -1,0 +1,111 @@
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+import db from "../db/index.js";
+import { task } from "../db/schema.js";
+import type { NewTask } from "../db/schema.js";
+import { parseRequestBody, removeUndefined } from "./utils.js";
+
+type Database = typeof db;
+
+const taskBaseSchema = z.object({
+  description: z.string().min(1),
+  skill: z.string().min(1),
+  target: z.string().min(1).nullable().optional(),
+});
+
+const taskCreateSchema = taskBaseSchema.extend({
+  id: z.string().min(1).optional(),
+});
+
+const taskUpdateSchema = taskBaseSchema
+  .partial()
+  .refine(
+    (data) => Object.values(data).some((value) => value !== undefined),
+    { message: "At least one field must be provided" },
+  );
+
+export function createTaskRoutes(database: Database = db) {
+  const routes = new Hono();
+
+  routes.get("/", async (c) => {
+    const items = await database.select().from(task);
+    return c.json(items);
+  });
+
+  routes.get("/:id", async (c) => {
+    const { id } = c.req.param();
+    const result = await database
+      .select()
+      .from(task)
+      .where(eq(task.id, id));
+    if (result.length === 0) {
+      return c.json({ error: "Task not found" }, 404);
+    }
+    return c.json(result[0]);
+  });
+
+  routes.post("/", async (c) => {
+    const parsed = await parseRequestBody(
+      c,
+      taskCreateSchema,
+      "Invalid task payload",
+    );
+    if (!parsed.success) {
+      return parsed.response;
+    }
+
+    const { id, ...rest } = parsed.data;
+    const values: NewTask = {
+      description: rest.description,
+      skill: rest.skill,
+      target: rest.target ?? null,
+    };
+    if (id) {
+      values.id = id;
+    }
+
+    const inserted = await database.insert(task).values(values).returning();
+    return c.json(inserted[0], 201);
+  });
+
+  routes.post("/:id", async (c) => {
+    const { id } = c.req.param();
+    const parsed = await parseRequestBody(
+      c,
+      taskUpdateSchema,
+      "Invalid task payload",
+    );
+    if (!parsed.success) {
+      return parsed.response;
+    }
+
+    const updateData: Partial<NewTask> = removeUndefined(parsed.data);
+    const updated = await database
+      .update(task)
+      .set(updateData)
+      .where(eq(task.id, id))
+      .returning();
+    if (updated.length === 0) {
+      return c.json({ error: "Task not found" }, 404);
+    }
+    return c.json(updated[0]);
+  });
+
+  routes.delete("/:id", async (c) => {
+    const { id } = c.req.param();
+    const deleted = await database
+      .delete(task)
+      .where(eq(task.id, id))
+      .returning();
+    if (deleted.length === 0) {
+      return c.json({ error: "Task not found" }, 404);
+    }
+    return c.json(deleted[0]);
+  });
+
+  return routes;
+}
+
+export const taskRoutes = createTaskRoutes();

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -1,0 +1,43 @@
+import type { Context } from "hono";
+import { z } from "zod";
+
+type ParseSuccess<T> = { success: true; data: T };
+type ParseFailure = { success: false; response: Response };
+
+export async function parseRequestBody<T>(
+  c: Context,
+  schema: z.ZodType<T>,
+  errorMessage: string,
+): Promise<ParseSuccess<T> | ParseFailure> {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return {
+      success: false,
+      response: c.json({ error: "Invalid JSON body" }, 400),
+    };
+  }
+
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    return {
+      success: false,
+      response: c.json(
+        {
+          error: errorMessage,
+          details: result.error.flatten(),
+        },
+        400,
+      ),
+    };
+  }
+
+  return { success: true, data: result.data };
+}
+
+export function removeUndefined<T extends Record<string, unknown>>(input: T) {
+  return Object.fromEntries(
+    Object.entries(input).filter(([, value]) => value !== undefined),
+  ) as Partial<T>;
+}


### PR DESCRIPTION
## Summary
- extract the schedule, task, and duplicant route handlers into dedicated modules with a shared helper and aggregated API router
- simplify the server entry to mount the modular API router and keep startup logic focused on bootstrapping
- add focused Vitest suites for each route group covering representative success and error scenarios

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c8e9bd6c10832bafcc7dc10991777e