### PR TITLE
Add test suites for definition syncing utilities

### DIFF
--- a/src/lib/items.test.ts
+++ b/src/lib/items.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readFileMock = vi.fn();
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock("node:fs/promises", () => ({
+  readFile: readFileMock,
+}));
+
+vi.mock("../db/index.js", () => ({
+  __esModule: true,
+  default: {
+    select: selectMock,
+    insert: insertMock,
+    delete: deleteMock,
+  },
+}));
+
+type ItemsModule = typeof import("./items.js");
+let items: ItemsModule;
+
+function mockSelect(result: unknown, opts: { raw?: boolean } = {}) {
+  if (opts.raw) {
+    const from = vi.fn().mockResolvedValue(result);
+    selectMock.mockReturnValueOnce({ from });
+    return { from };
+  }
+
+  const where = vi.fn().mockResolvedValue(result);
+  const from = vi.fn().mockReturnValue({ where });
+  selectMock.mockReturnValueOnce({ from });
+  return { from, where };
+}
+
+function mockDelete(result: unknown = undefined) {
+  const where = vi.fn().mockResolvedValue(result);
+  deleteMock.mockReturnValueOnce({ where });
+  return { where };
+}
+
+function mockInsert() {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  insertMock.mockReturnValueOnce({ values });
+  return { values, onConflictDoUpdate };
+}
+
+describe("items library", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    readFileMock.mockReset();
+    selectMock.mockReset();
+    insertMock.mockReset();
+    deleteMock.mockReset();
+    items = await import("./items.js");
+  });
+
+  afterEach(() => {
+    delete process.env.ITEM_DEFS_PATH;
+    delete process.env.ITEM_DEFS_OPTIONAL;
+    delete process.env.ITEM_DEFS_PRUNE;
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes both array and wrapped file formats", () => {
+    const { parseItemDefs } = items;
+
+    const arrayResult = parseItemDefs([
+      { id: "iron", name: "Iron", category: "material" as const },
+    ]);
+    expect(arrayResult).toEqual([
+      {
+        id: "iron",
+        name: "Iron",
+        category: "material",
+        stack: { max: 1 },
+        weight: 0,
+        metadata: {},
+      },
+    ]);
+
+    const wrappedResult = parseItemDefs({
+      items: [
+        {
+          id: "berry",
+          name: "Berry",
+          category: "consumable",
+          stack: { max: 10, default: 5 },
+          weight: 2,
+          metadata: { rarity: "common" },
+        },
+      ],
+    });
+    expect(wrappedResult).toEqual([
+      {
+        id: "berry",
+        name: "Berry",
+        category: "consumable",
+        stack: { max: 10, default: 5 },
+        weight: 2,
+        metadata: { rarity: "common" },
+      },
+    ]);
+  });
+
+  it("rejects invalid item definitions", () => {
+    const { parseItemDefs } = items;
+    expect(() => parseItemDefs({})).toThrowError(/Invalid input/);
+  });
+
+  it("maps parsed items to database insert payload", () => {
+    const { toNewItemDef } = items;
+    const parsed = {
+      id: "ingot",
+      name: "Copper Ingot",
+      category: "material" as const,
+      stack: { max: 50 },
+      weight: 1,
+      metadata: { grade: "refined" },
+    };
+
+    expect(toNewItemDef(parsed)).toEqual({
+      id: "ingot",
+      name: "Copper Ingot",
+      category: "material",
+      stackMax: 50,
+      weight: 1,
+      metadata: { grade: "refined" },
+    });
+  });
+
+  it("loads item definitions from a file", async () => {
+    const { loadItemDefsFromFile } = items;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([{ id: "wood", name: "Wood", category: "material" }]),
+    );
+
+    const defs = await loadItemDefsFromFile("/tmp/items.json");
+    expect(defs).toEqual([
+      {
+        id: "wood",
+        name: "Wood",
+        category: "material",
+        stack: { max: 1 },
+        weight: 0,
+        metadata: {},
+      },
+    ]);
+    expect(readFileMock).toHaveBeenCalledWith("/tmp/items.json", "utf8");
+  });
+
+  it("short-circuits syncing when there are no item definitions", async () => {
+    const { syncItemDefsFromFile } = items;
+    readFileMock.mockResolvedValueOnce(JSON.stringify([]));
+
+    const result = await syncItemDefsFromFile("/tmp/items.json");
+    expect(result).toEqual({ inserted: 0, updated: 0, pruned: 0, total: 0 });
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("computes inserted and updated counts in dry-run mode", async () => {
+    const { syncItemDefsFromFile } = items;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([
+        { id: "existing", name: "Existing", category: "material" },
+        { id: "new", name: "New", category: "material" },
+      ]),
+    );
+
+    mockSelect([{ id: "existing" }]);
+
+    const result = await syncItemDefsFromFile("/tmp/items.json", { dryRun: true });
+    expect(result).toEqual({ inserted: 1, updated: 1, pruned: 0, total: 2 });
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("upserts items and prunes missing ones when requested", async () => {
+    const { syncItemDefsFromFile } = items;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([
+        { id: "existing", name: "Existing", category: "material" },
+        { id: "new", name: "New", category: "consumable" },
+      ]),
+    );
+
+    mockSelect([{ id: "existing" }]);
+    mockSelect([{ id: "existing" }, { id: "legacy" }], { raw: true });
+    const { values, onConflictDoUpdate } = mockInsert();
+    const { where: deleteWhere } = mockDelete();
+
+    const result = await syncItemDefsFromFile("/tmp/items.json", { prune: true });
+
+    expect(result).toEqual({ inserted: 1, updated: 1, pruned: 1, total: 2 });
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(values.mock.calls[0][0]).toEqual([
+      {
+        id: "existing",
+        name: "Existing",
+        category: "material",
+        stackMax: 1,
+        weight: 0,
+        metadata: {},
+      },
+      {
+        id: "new",
+        name: "New",
+        category: "consumable",
+        stackMax: 1,
+        weight: 0,
+        metadata: {},
+      },
+    ]);
+    expect(onConflictDoUpdate).toHaveBeenCalledWith({
+      target: expect.anything(),
+      set: expect.objectContaining({
+        name: expect.anything(),
+        category: expect.anything(),
+        stackMax: expect.anything(),
+        weight: expect.anything(),
+        metadata: expect.anything(),
+        updatedAt: expect.any(Date),
+      }),
+    });
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs sync results during startup", async () => {
+    const { ensureItemDefsSyncedOnStart } = items;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([{ id: "startup", name: "Startup", category: "material" }]),
+    );
+    mockSelect([]);
+    const { values } = mockInsert();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await ensureItemDefsSyncedOnStart();
+
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      "[items] synced 1 defs (inserted: 1, updated: 0) from ./data/items.json",
+    );
+  });
+
+  it("optionally suppresses missing definition files", async () => {
+    const { ensureItemDefsSyncedOnStart } = items;
+    process.env.ITEM_DEFS_PATH = "./missing.json";
+    process.env.ITEM_DEFS_OPTIONAL = "true";
+
+    const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
+    readFileMock.mockRejectedValueOnce(missing);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureItemDefsSyncedOnStart()).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[items] item defs file not found at ./missing.json; skipping.",
+    );
+  });
+
+  it("rethrows non-optional missing files with guidance", async () => {
+    const { ensureItemDefsSyncedOnStart } = items;
+    process.env.ITEM_DEFS_PATH = "./missing.json";
+    const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
+    readFileMock.mockRejectedValueOnce(missing);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureItemDefsSyncedOnStart()).rejects.toThrow("missing");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[items] item defs file not found at ./missing.json. Set ITEM_DEFS_OPTIONAL=true to skip.",
+    );
+  });
+});

--- a/src/lib/skill-targets.test.ts
+++ b/src/lib/skill-targets.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readFileMock = vi.fn();
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock("node:fs/promises", () => ({
+  readFile: readFileMock,
+}));
+
+vi.mock("../db/index.js", () => ({
+  __esModule: true,
+  default: {
+    select: selectMock,
+    insert: insertMock,
+    delete: deleteMock,
+  },
+}));
+
+type SkillTargetsModule = typeof import("./skill-targets.js");
+let skillTargets: SkillTargetsModule;
+
+function mockSelect(result: unknown, opts: { raw?: boolean } = {}) {
+  if (opts.raw) {
+    const from = vi.fn().mockResolvedValue(result);
+    selectMock.mockReturnValueOnce({ from });
+    return { from };
+  }
+
+  const where = vi.fn().mockResolvedValue(result);
+  const from = vi.fn().mockReturnValue({ where });
+  selectMock.mockReturnValueOnce({ from });
+  return { from, where };
+}
+
+function mockDelete(result: unknown = undefined) {
+  const where = vi.fn().mockResolvedValue(result);
+  deleteMock.mockReturnValueOnce({ where });
+  return { where };
+}
+
+function mockInsert() {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  insertMock.mockReturnValueOnce({ values });
+  return { values, onConflictDoUpdate };
+}
+
+describe("skill target library", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    readFileMock.mockReset();
+    selectMock.mockReset();
+    insertMock.mockReset();
+    deleteMock.mockReset();
+    skillTargets = await import("./skill-targets.js");
+  });
+
+  afterEach(() => {
+    delete process.env.SKILL_TARGET_DEFS_PATH;
+    delete process.env.SKILL_TARGET_DEFS_OPTIONAL;
+    delete process.env.SKILL_TARGET_DEFS_PRUNE;
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes both array and wrapped file formats", () => {
+    const { parseSkillTargetDefs } = skillTargets;
+
+    const arrayResult = parseSkillTargetDefs([
+      { id: "target-1", name: "Target One" },
+    ]);
+    expect(arrayResult).toEqual([
+      {
+        id: "target-1",
+        name: "Target One",
+        requirements: {},
+        metadata: {},
+      },
+    ]);
+
+    const wrappedResult = parseSkillTargetDefs({
+      targets: [
+        {
+          id: "target-2",
+          name: "Target Two",
+          requirements: { skill: "digging" },
+          metadata: { difficulty: "hard" },
+        },
+      ],
+    });
+    expect(wrappedResult).toEqual([
+      {
+        id: "target-2",
+        name: "Target Two",
+        requirements: { skill: "digging" },
+        metadata: { difficulty: "hard" },
+      },
+    ]);
+  });
+
+  it("rejects invalid skill target definitions", () => {
+    const { parseSkillTargetDefs } = skillTargets;
+    expect(() => parseSkillTargetDefs({})).toThrowError(/Invalid input/);
+  });
+
+  it("maps parsed skill targets to database insert payload", () => {
+    const { toNewSkillTargetDef } = skillTargets;
+    const parsed = {
+      id: "target-3",
+      name: "Target Three",
+      requirements: { minLevel: 2 },
+      metadata: { zone: "asteroid" },
+    };
+
+    expect(toNewSkillTargetDef(parsed)).toEqual({
+      id: "target-3",
+      name: "Target Three",
+      requirements: { minLevel: 2 },
+      metadata: { zone: "asteroid" },
+    });
+  });
+
+  it("loads skill target definitions from a file", async () => {
+    const { loadSkillTargetDefsFromFile } = skillTargets;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([{ id: "target-4", name: "Target Four" }]),
+    );
+
+    const defs = await loadSkillTargetDefsFromFile("/tmp/skill-targets.json");
+    expect(defs).toEqual([
+      {
+        id: "target-4",
+        name: "Target Four",
+        requirements: {},
+        metadata: {},
+      },
+    ]);
+    expect(readFileMock).toHaveBeenCalledWith("/tmp/skill-targets.json", "utf8");
+  });
+
+  it("short-circuits syncing when there are no skill targets", async () => {
+    const { syncSkillTargetDefsFromFile } = skillTargets;
+    readFileMock.mockResolvedValueOnce(JSON.stringify([]));
+
+    const result = await syncSkillTargetDefsFromFile("/tmp/skill-targets.json");
+    expect(result).toEqual({ inserted: 0, updated: 0, pruned: 0, total: 0 });
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("computes inserted and updated counts in dry-run mode", async () => {
+    const { syncSkillTargetDefsFromFile } = skillTargets;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([
+        { id: "existing", name: "Existing" },
+        { id: "new", name: "New" },
+      ]),
+    );
+
+    mockSelect([{ id: "existing" }]);
+
+    const result = await syncSkillTargetDefsFromFile("/tmp/skill-targets.json", {
+      dryRun: true,
+    });
+    expect(result).toEqual({ inserted: 1, updated: 1, pruned: 0, total: 2 });
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("upserts skill targets and prunes missing ones when requested", async () => {
+    const { syncSkillTargetDefsFromFile } = skillTargets;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([
+        { id: "existing", name: "Existing" },
+        { id: "new", name: "New" },
+      ]),
+    );
+
+    mockSelect([{ id: "existing" }]);
+    mockSelect([{ id: "existing" }, { id: "legacy" }], { raw: true });
+    const { values, onConflictDoUpdate } = mockInsert();
+    const { where: deleteWhere } = mockDelete();
+
+    const result = await syncSkillTargetDefsFromFile("/tmp/skill-targets.json", {
+      prune: true,
+    });
+
+    expect(result).toEqual({ inserted: 1, updated: 1, pruned: 1, total: 2 });
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(values.mock.calls[0][0]).toEqual([
+      {
+        id: "existing",
+        name: "Existing",
+        requirements: {},
+        metadata: {},
+      },
+      {
+        id: "new",
+        name: "New",
+        requirements: {},
+        metadata: {},
+      },
+    ]);
+    expect(onConflictDoUpdate).toHaveBeenCalledWith({
+      target: expect.anything(),
+      set: expect.objectContaining({
+        name: expect.anything(),
+        requirements: expect.anything(),
+        metadata: expect.anything(),
+        updatedAt: expect.any(Date),
+      }),
+    });
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs sync results during startup", async () => {
+    const { ensureSkillTargetDefsSyncedOnStart } = skillTargets;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([{ id: "startup", name: "Startup" }]),
+    );
+    mockSelect([]);
+    const { values } = mockInsert();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await ensureSkillTargetDefsSyncedOnStart();
+
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      "[skill-targets] synced 1 defs (inserted: 1, updated: 0) from ./data/skill-targets.json",
+    );
+  });
+
+  it("optionally suppresses missing definition files", async () => {
+    const { ensureSkillTargetDefsSyncedOnStart } = skillTargets;
+    process.env.SKILL_TARGET_DEFS_PATH = "./missing.json";
+    process.env.SKILL_TARGET_DEFS_OPTIONAL = "true";
+
+    const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
+    readFileMock.mockRejectedValueOnce(missing);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureSkillTargetDefsSyncedOnStart()).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[skill-targets] defs file not found at ./missing.json; skipping.",
+    );
+  });
+
+  it("rethrows non-optional missing files with guidance", async () => {
+    const { ensureSkillTargetDefsSyncedOnStart } = skillTargets;
+    process.env.SKILL_TARGET_DEFS_PATH = "./missing.json";
+    const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
+    readFileMock.mockRejectedValueOnce(missing);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureSkillTargetDefsSyncedOnStart()).rejects.toThrow("missing");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[skill-targets] defs file not found at ./missing.json. Set SKILL_TARGET_DEFS_OPTIONAL=true to skip.",
+    );
+  });
+});

--- a/src/lib/skills.test.ts
+++ b/src/lib/skills.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readFileMock = vi.fn();
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock("node:fs/promises", () => ({
+  readFile: readFileMock,
+}));
+
+vi.mock("../db/index.js", () => ({
+  __esModule: true,
+  default: {
+    select: selectMock,
+    insert: insertMock,
+    delete: deleteMock,
+  },
+}));
+
+type SkillsModule = typeof import("./skills.js");
+let skills: SkillsModule;
+
+function mockSelect(result: unknown, opts: { raw?: boolean } = {}) {
+  if (opts.raw) {
+    const from = vi.fn().mockResolvedValue(result);
+    selectMock.mockReturnValueOnce({ from });
+    return { from };
+  }
+
+  const where = vi.fn().mockResolvedValue(result);
+  const from = vi.fn().mockReturnValue({ where });
+  selectMock.mockReturnValueOnce({ from });
+  return { from, where };
+}
+
+function mockDelete(result: unknown = undefined) {
+  const where = vi.fn().mockResolvedValue(result);
+  deleteMock.mockReturnValueOnce({ where });
+  return { where };
+}
+
+function mockInsert() {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  insertMock.mockReturnValueOnce({ values });
+  return { values, onConflictDoUpdate };
+}
+
+describe("skills library", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    readFileMock.mockReset();
+    selectMock.mockReset();
+    insertMock.mockReset();
+    deleteMock.mockReset();
+    skills = await import("./skills.js");
+  });
+
+  afterEach(() => {
+    delete process.env.SKILL_DEFS_PATH;
+    delete process.env.SKILL_DEFS_OPTIONAL;
+    delete process.env.SKILL_DEFS_PRUNE;
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes both array and wrapped file formats", () => {
+    const { parseSkillDefs } = skills;
+
+    const arrayResult = parseSkillDefs([
+      { id: "mining", name: "Mining", priority: 1 },
+    ]);
+    expect(arrayResult).toEqual([
+      {
+        id: "mining",
+        name: "Mining",
+        priority: 1,
+        requirements: {},
+        metadata: {},
+      },
+    ]);
+
+    const wrappedResult = parseSkillDefs({
+      skills: [
+        {
+          id: "research",
+          name: "Research",
+          priority: 3,
+          requirements: { tier: 2 },
+          metadata: { category: "science" },
+        },
+      ],
+    });
+    expect(wrappedResult).toEqual([
+      {
+        id: "research",
+        name: "Research",
+        priority: 3,
+        requirements: { tier: 2 },
+        metadata: { category: "science" },
+      },
+    ]);
+  });
+
+  it("rejects invalid skill definitions", () => {
+    const { parseSkillDefs } = skills;
+    expect(() => parseSkillDefs({})).toThrowError(/Invalid input/);
+  });
+
+  it("maps parsed skills to database insert payload", () => {
+    const { toNewSkillDef } = skills;
+    const parsed = {
+      id: "cooking",
+      name: "Cooking",
+      priority: 2,
+      requirements: { heat: true },
+      metadata: { station: "stove" },
+    };
+
+    expect(toNewSkillDef(parsed)).toEqual({
+      id: "cooking",
+      name: "Cooking",
+      priority: 2,
+      requirements: { heat: true },
+      metadata: { station: "stove" },
+    });
+  });
+
+  it("loads skill definitions from a file", async () => {
+    const { loadSkillDefsFromFile } = skills;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([{ id: "art", name: "Art" }]),
+    );
+
+    const defs = await loadSkillDefsFromFile("/tmp/skills.json");
+    expect(defs).toEqual([
+      {
+        id: "art",
+        name: "Art",
+        priority: 0,
+        requirements: {},
+        metadata: {},
+      },
+    ]);
+    expect(readFileMock).toHaveBeenCalledWith("/tmp/skills.json", "utf8");
+  });
+
+  it("short-circuits syncing when there are no skill definitions", async () => {
+    const { syncSkillDefsFromFile } = skills;
+    readFileMock.mockResolvedValueOnce(JSON.stringify([]));
+
+    const result = await syncSkillDefsFromFile("/tmp/skills.json");
+    expect(result).toEqual({ inserted: 0, updated: 0, pruned: 0, total: 0 });
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("computes inserted and updated counts in dry-run mode", async () => {
+    const { syncSkillDefsFromFile } = skills;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([
+        { id: "existing", name: "Existing" },
+        { id: "new", name: "New" },
+      ]),
+    );
+
+    mockSelect([{ id: "existing" }]);
+
+    const result = await syncSkillDefsFromFile("/tmp/skills.json", { dryRun: true });
+    expect(result).toEqual({ inserted: 1, updated: 1, pruned: 0, total: 2 });
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("upserts skills and prunes missing ones when requested", async () => {
+    const { syncSkillDefsFromFile } = skills;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([
+        { id: "existing", name: "Existing" },
+        { id: "new", name: "New" },
+      ]),
+    );
+
+    mockSelect([{ id: "existing" }]);
+    mockSelect([{ id: "existing" }, { id: "legacy" }], { raw: true });
+    const { values, onConflictDoUpdate } = mockInsert();
+    const { where: deleteWhere } = mockDelete();
+
+    const result = await syncSkillDefsFromFile("/tmp/skills.json", { prune: true });
+
+    expect(result).toEqual({ inserted: 1, updated: 1, pruned: 1, total: 2 });
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(values.mock.calls[0][0]).toEqual([
+      {
+        id: "existing",
+        name: "Existing",
+        priority: 0,
+        requirements: {},
+        metadata: {},
+      },
+      {
+        id: "new",
+        name: "New",
+        priority: 0,
+        requirements: {},
+        metadata: {},
+      },
+    ]);
+    expect(onConflictDoUpdate).toHaveBeenCalledWith({
+      target: expect.anything(),
+      set: expect.objectContaining({
+        name: expect.anything(),
+        priority: expect.anything(),
+        requirements: expect.anything(),
+        metadata: expect.anything(),
+        updatedAt: expect.any(Date),
+      }),
+    });
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs sync results during startup", async () => {
+    const { ensureSkillDefsSyncedOnStart } = skills;
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify([{ id: "startup", name: "Startup" }]),
+    );
+    mockSelect([]);
+    const { values } = mockInsert();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await ensureSkillDefsSyncedOnStart();
+
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      "[skills] synced 1 defs (inserted: 1, updated: 0) from ./data/skills.json",
+    );
+  });
+
+  it("optionally suppresses missing definition files", async () => {
+    const { ensureSkillDefsSyncedOnStart } = skills;
+    process.env.SKILL_DEFS_PATH = "./missing.json";
+    process.env.SKILL_DEFS_OPTIONAL = "true";
+
+    const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
+    readFileMock.mockRejectedValueOnce(missing);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureSkillDefsSyncedOnStart()).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[skills] skill defs file not found at ./missing.json; skipping.",
+    );
+  });
+
+  it("rethrows non-optional missing files with guidance", async () => {
+    const { ensureSkillDefsSyncedOnStart } = skills;
+    process.env.SKILL_DEFS_PATH = "./missing.json";
+    const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
+    readFileMock.mockRejectedValueOnce(missing);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensureSkillDefsSyncedOnStart()).rejects.toThrow("missing");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[skills] skill defs file not found at ./missing.json. Set SKILL_DEFS_OPTIONAL=true to skip.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive tests for item definition parsing, syncing, and startup logging
- add analogous coverage for skill and skill-target definition helpers, including prune and dry-run paths
- exercise startup handling for optional definition files across all sync utilities

## Testing
- pnpm vitest run --root ./src --coverage
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c93db4aca0832ba954435e0cd3d1e6