### PR TITLE
Use Drizzle query relations for route lookups

### DIFF
--- a/src/routes/duplicant.ts
+++ b/src/routes/duplicant.ts
@@ -36,20 +36,30 @@ export function createDuplicantRoutes(database: Database = db) {
   const routes = new Hono();
 
   routes.get("/", async (c) => {
-    const items = await database.select().from(duplicant);
+    const items = await database.query.duplicant.findMany({
+      with: {
+        schedule: true,
+        task: true,
+        stats: true,
+      },
+    });
     return c.json(items);
   });
 
   routes.get("/:id", async (c) => {
     const { id } = c.req.param();
-    const result = await database
-      .select()
-      .from(duplicant)
-      .where(eq(duplicant.id, id));
-    if (result.length === 0) {
+    const result = await database.query.duplicant.findFirst({
+      where: (duplicants, { eq }) => eq(duplicants.id, id),
+      with: {
+        schedule: true,
+        task: true,
+        stats: true,
+      },
+    });
+    if (!result) {
       return c.json({ error: "Duplicant not found" }, 404);
     }
-    return c.json(result[0]);
+    return c.json(result);
   });
 
   routes.post("/", async (c) => {

--- a/src/routes/schedule.ts
+++ b/src/routes/schedule.ts
@@ -39,20 +39,26 @@ export function createScheduleRoutes(database: Database = db) {
   const routes = new Hono();
 
   routes.get("/", async (c) => {
-    const items = await database.select().from(schedule);
+    const items = await database.query.schedule.findMany({
+      with: {
+        duplicants: true,
+      },
+    });
     return c.json(items);
   });
 
   routes.get("/:id", async (c) => {
     const { id } = c.req.param();
-    const result = await database
-      .select()
-      .from(schedule)
-      .where(eq(schedule.id, id));
-    if (result.length === 0) {
+    const result = await database.query.schedule.findFirst({
+      where: (schedules, { eq }) => eq(schedules.id, id),
+      with: {
+        duplicants: true,
+      },
+    });
+    if (!result) {
       return c.json({ error: "Schedule not found" }, 404);
     }
-    return c.json(result[0]);
+    return c.json(result);
   });
 
   routes.post("/", async (c) => {

--- a/src/routes/task.ts
+++ b/src/routes/task.ts
@@ -29,17 +29,26 @@ export function createTaskRoutes(database: Database = db) {
   const routes = new Hono();
 
   routes.get("/", async (c) => {
-    const items = await database.select().from(task);
+    const items = await database.query.task.findMany({
+      with: {
+        duplicants: true,
+      },
+    });
     return c.json(items);
   });
 
   routes.get("/:id", async (c) => {
     const { id } = c.req.param();
-    const result = await database.select().from(task).where(eq(task.id, id));
-    if (result.length === 0) {
+    const result = await database.query.task.findFirst({
+      where: (tasks, { eq }) => eq(tasks.id, id),
+      with: {
+        duplicants: true,
+      },
+    });
+    if (!result) {
       return c.json({ error: "Task not found" }, 404);
     }
-    return c.json(result[0]);
+    return c.json(result);
   });
 
   routes.post("/", async (c) => {


### PR DESCRIPTION
## Summary
- use the Drizzle query API to preload related records when listing or fetching duplicants, schedules, and tasks
- update the associated route unit tests to mock the query helpers and assert that relations are eagerly loaded

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c94a765160832ba44c2d8402bbfe18