### PR TITLE
Improve startup defaults and API ergonomics

### DIFF
--- a/data/skills.json
+++ b/data/skills.json
@@ -1,10 +1,11 @@
 {
-  "targets": [
+  "skills": [
     {
-      "id": "rock_small",
-      "name": "Small Rock",
-      "requirements": { "hardness": 1 },
-      "metadata": { "zone": "A1" }
+      "id": "digging",
+      "name": "Digging",
+      "priority": 0,
+      "requirements": { "tool": "shovel" },
+      "metadata": { "category": "mining" }
     }
   ]
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -22,26 +22,38 @@ const db = drizzle({ client, schema });
 type Database = typeof db;
 
 export async function ensureDefaultSchedule(database: Database = db) {
-  await database
-    .insert(schedule)
-    .values({
-      id: DEFAULT_SCHEDULE_ID,
-      activities: DEFAULT_SCHEDULE_ACTIVITIES,
-    })
-    .onConflictDoNothing({ target: schedule.id });
+  const existing = await database
+    .select({ id: schedule.id })
+    .from(schedule)
+    .where(eq(schedule.id, DEFAULT_SCHEDULE_ID));
+
+  if (existing.length > 0) {
+    return;
+  }
+
+  await database.insert(schedule).values({
+    id: DEFAULT_SCHEDULE_ID,
+    activities: DEFAULT_SCHEDULE_ACTIVITIES,
+  });
 }
 
 // NEW: ensure a global "idle" task exists
 export async function ensureDefaultIdleTask(database: Database = db) {
-  await database
-    .insert(task)
-    .values({
-      id: DEFAULT_IDLE_TASK_ID,
-      description: "Idle",
-      skillId: "idle",
-      targetId: null,
-    })
-    .onConflictDoNothing({ target: task.id });
+  const existing = await database
+    .select({ id: task.id })
+    .from(task)
+    .where(eq(task.id, DEFAULT_IDLE_TASK_ID));
+
+  if (existing.length > 0) {
+    return;
+  }
+
+  await database.insert(task).values({
+    id: DEFAULT_IDLE_TASK_ID,
+    description: "Idle",
+    skillId: "idle",
+    targetId: null,
+  });
 }
 
 export default db;

--- a/src/routes/duplicant.test.ts
+++ b/src/routes/duplicant.test.ts
@@ -266,7 +266,10 @@ describe("duplicant routes", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual(updated);
-    expect(set).toHaveBeenCalledWith({ name: "Ada Updated", task: "task-99" });
+    expect(set).toHaveBeenCalledWith({
+      name: "Ada Updated",
+      taskId: "task-99",
+    });
   });
 
   it("returns 404 when updating a missing duplicant", async () => {


### PR DESCRIPTION
## Summary
- guard default schedule and idle task bootstrapping with explicit existence checks
- accept task/schedule aliases in duplicant and task APIs while refining validation, and adjust tests accordingly
- harden skill definition sync and inventory listing for mock-friendly behaviour and fix sample skill data

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c95672b018832b88e4a73dd38025e7